### PR TITLE
Add Xacro and launch files for basic FT sensor

### DIFF
--- a/ur_gazebo/launch/inc/load_ur.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur.launch.xml
@@ -30,7 +30,13 @@
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />
 
-  <param name="robot_description" command="$(find xacro)/xacro '$(find ur_gazebo)/urdf/ur.xacro'
+  <!-- FT sensor choice -->
+  <arg name="use_ft" />
+  <arg unless="$(arg use_ft)" name="xacro_filename" value="ur" />
+  <arg if="$(arg use_ft)" name="xacro_filename" value="ur_ftbasic" />
+
+  <!-- Pass robot description with parameters and configurations -->
+  <param name="robot_description" command="$(find xacro)/xacro '$(find ur_gazebo)/urdf/$(arg xacro_filename).xacro'
     joint_limit_params:=$(arg joint_limit_params)
     kinematics_params:=$(arg kinematics_params)
     physical_params:=$(arg physical_params)
@@ -38,6 +44,5 @@
     transmission_hw_interface:=$(arg transmission_hw_interface)
     safety_limits:=$(arg safety_limits)
     safety_pos_margin:=$(arg safety_pos_margin)
-    safety_k_position:=$(arg safety_k_position)"
-    />
+    safety_k_position:=$(arg safety_k_position)" />
 </launch>

--- a/ur_gazebo/launch/inc/load_ur5e_jointPosition.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur5e_jointPosition.launch.xml
@@ -12,6 +12,9 @@
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />
 
+  <!-- FT sensor configuration -->
+  <arg name="use_ft" /> 
+  
   <!-- Use common launch file and pass all arguments to it -->
   <include file="$(dirname)/load_ur.launch.xml" pass_all_args="true"/>
 </launch>

--- a/ur_gazebo/launch/ur5e_bringup_cartesianMotion.launch
+++ b/ur_gazebo/launch/ur5e_bringup_cartesianMotion.launch
@@ -50,12 +50,16 @@
   <arg name="paused" default="true" doc="Starts Gazebo in paused mode" />
   <arg name="gui" default="true" doc="Starts Gazebo gui" />
 
+  <!-- FT sensor configuration -->
+  <arg name="use_ft" default="true" /> 
+
   <!-- Load urdf on the parameter server -->
   <include file="$(arg robot_description_file)">
     <arg name="joint_limit_params" value="$(arg joint_limit_params)"/>
     <arg name="kinematics_params" value="$(arg kinematics_params)"/>
     <arg name="physical_params" value="$(arg physical_params)"/>
     <arg name="visual_params" value="$(arg visual_params)"/>
+    <arg name="use_ft" value="$(arg use_ft)" /> 
   </include>
 
   <!-- Robot state publisher -->

--- a/ur_gazebo/package.xml
+++ b/ur_gazebo/package.xml
@@ -29,6 +29,8 @@
   <exec_depend>position_controllers</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>ur_description</exec_depend>
+  <exec_depend>gazebo_plugins</exec_depend>
+  <exec_depend>gazebo_ros_pkgs</exec_depend>
 
   <export>
   </export>

--- a/ur_gazebo/urdf/ur_ftbasic.xacro
+++ b/ur_gazebo/urdf/ur_ftbasic.xacro
@@ -1,0 +1,126 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://wiki.ros.org/xacro" name="ur_robot_gazebo">
+  <!--
+    This is a top-level xacro instantiating the Gazebo-specific version of the
+    'ur_robot' macro (ie: 'ur_robot_gazebo') with basic force/torque sensor and passing it values for all its
+    required arguments 
+  -->
+
+  <!--
+    Import main macro.
+
+    NOTE: this imports the Gazebo-wrapper main macro, NOT the regular
+          xacro macro (which is hosted by ur_description).
+  -->
+  <xacro:include filename="$(find ur_gazebo)/urdf/ur_macro.xacro" />
+  <xacro:include filename="$(find ur_description)/urdf/inc/ur_common.xacro" />
+
+  <!--Declare arguments -->
+  <xacro:arg name="joint_limit_params" default="" />
+  <xacro:arg name="physical_params" default="" />
+  <xacro:arg name="kinematics_params" default="" />
+  <xacro:arg name="visual_params" default="" />
+
+  <!--
+    legal values:
+      - hardware_interface/PositionJointInterface
+      - hardware_interface/VelocityJointInterface
+      - hardware_interface/EffortJointInterface
+
+    NOTE: this value must correspond to the controller configured in the
+          controller .yaml files in the 'config' directory.
+  -->
+  <xacro:arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" />
+  <xacro:arg name="safety_limits" default="false" />
+  <xacro:arg name="safety_pos_margin" default="0.15" />
+  <xacro:arg name="safety_k_position" default="20" />
+
+  <!-- Instantiate the Gazebo robot and pass it all the required arguments. -->
+  <xacro:ur_robot_gazebo prefix="" joint_limits_parameters_file="$(arg joint_limit_params)" kinematics_parameters_file="$(arg kinematics_params)" physical_parameters_file="$(arg physical_params)" visual_parameters_file="$(arg visual_params)" transmission_hw_interface="$(arg transmission_hw_interface)" safety_limits="$(arg safety_limits)" safety_pos_margin="$(arg safety_pos_margin)" safety_k_position="$(arg safety_k_position)" />
+
+  <!--
+     TODO:  add ${prefix} to all following link, joint, and topic names, and resolve
+   -->
+  <!--
+    Attach the Gazebo model to Gazebo's world frame.
+
+    Note: if you're looking to integrate a UR into a larger scene and need
+    to add EEFs or other parts, DO NOT change this file or the 'world' link
+    here. Create a NEW xacro instead and decide whether you need to add
+    a 'world' link there.
+  -->
+  <link name="world" />
+  <joint name="world_joint" type="fixed">
+    <parent link="world" />
+    <child link="base_link" />
+    <origin xyz="0 0 0" rpy="0 0 0" />
+  </joint>
+
+  <!-- 
+    Force torque sensor link, joint, and Gazebo definition
+    TODO:  parameterize FT sensor properties, e.g. choose Optoforce or OnRobotics by YAML 
+  -->
+
+  <link name="ft_sensor_link">
+    <visual>
+      <origin rpy="0 0 0" xyz="0 0 0.025" />
+      <geometry>
+        <cylinder radius="0.035" length="0.05" />
+      </geometry>
+      <material name="LightGrey">
+        <color rgba="0.7 0.7 0.7 1.0" />
+      </material>
+    </visual>
+    <collision>
+      <origin rpy="0 0 0" xyz="0 0 0.025" />
+      <geometry>
+        <cylinder radius="0.035" length="0.05" />
+      </geometry>
+    </collision>
+    <inertial>
+      <mass value="0.100" />
+      <origin rpy="0 0 0" xyz="0.0 0.0 0.025" />
+      <inertia ixx="9.890410052167731e-05" ixy="0.0" ixz="0.0" iyy="9.890410052167731e-05" iyz="0.0" izz="0.0001321171875" />
+    </inertial>
+  </link>
+
+  <!-- Use revolute joint as Gazebo's internal URDF to SRDF convertion lumps fixed links in parent -->
+  <joint name="ft_sensor_joint" type="revolute">
+    <parent link="wrist_3_link" />
+    <child link="ft_sensor_link" />
+    <origin xyz="0 0 0.001" rpy="0 0 0" />
+    <axis xyz="0 0 1" />
+    <limit lower="0" upper="0" effort="0" velocity="0" />
+    <dynamics damping="0" friction="0" />
+  </joint>
+
+  <!-- Disable collision with previous link -->
+  <disable_collisions link1="ft_sensor_link" link2="wrist_3_link" reason="Adjacent" />
+
+  <!-- Enable Gazebo sensor on joint -->
+  <gazebo reference="ft_sensor_joint">
+    <pose>0 0 0 0 0 0</pose>
+    <sensor name="ft_sensor" type="force_torque">
+      <always_on>true</always_on>
+      <update_rate>10.0</update_rate>
+      <visualize>true</visualize>
+      <force_torque>
+        <frame>sensor</frame>
+        <measure_direction>child_to_parent</measure_direction>
+      </force_torque>
+    </sensor>
+  </gazebo>
+
+  <!-- Use gazebo_ros_pkgs ft_sensor library to publish ft_sensor_topic by referencing ft_sensor_joint -->
+  <gazebo>
+    <plugin name="ft_sensor_plugin" filename="libgazebo_ros_ft_sensor.so">
+      <topicName>ft_sensor/ft_sensor_topic</topicName>
+      <jointName>ft_sensor_joint</jointName>
+      <noise>
+        <type>gaussian</type>
+        <mean>0.0</mean>
+        <stddev>0.003</stddev> <!-- change this to simulate noise -->
+      </noise>
+    </plugin>
+  </gazebo>
+</robot>


### PR DESCRIPTION
Using Gazebo's built in FT sensor, an extra link  as  cylinder is created with a "fixed" revolute joint. These changes take place in a new file called `ur_ftbasic.xacro`. The file is used as a `robot_description` when it is called from the launch files. The addition consists of a link, joint, Gazebo FT sensor on said joint, and ROS node to publish wrench information. The used node is given by the file `libgazebo_ros_ft_sensor.so` from `gazebo_ros_pkgs` which `rosdep` will handle as it is added to `package.xml`

The launch files `ur5e_bringup_cartesianMotion.launch`, `load_ur5e_jointPosition.launch.xml`, and `load_ur.launch.xml` are modified to call `ur_ftbasic.xacro` instead of `ur.xacro` by default, thus calling the robot with the sensor. The launch argument `useft` can be set to control this.

This answers to ticket `MPD-2307`.