### PR TITLE
Camexplore

### DIFF
--- a/ur_description/urdf/inc/ur_common.xacro
+++ b/ur_description/urdf/inc/ur_common.xacro
@@ -29,10 +29,10 @@
   -->
   <xacro:macro name="read_model_data" params="joint_limits_parameters_file kinematics_parameters_file physical_parameters_file visual_parameters_file">
     <!-- Read .yaml files from disk, load content into properties -->
-    <xacro:property name="config_joint_limit_parameters" value="${load_yaml(joint_limits_parameters_file)}"/>
-    <xacro:property name="config_kinematics_parameters" value="${load_yaml(kinematics_parameters_file)}"/>
-    <xacro:property name="config_physical_parameters" value="${load_yaml(physical_parameters_file)}"/>
-    <xacro:property name="config_visual_parameters" value="${load_yaml(visual_parameters_file)}"/>
+    <xacro:property name="config_joint_limit_parameters" value="${xacro.load_yaml(joint_limits_parameters_file)}"/>
+    <xacro:property name="config_kinematics_parameters" value="${xacro.load_yaml(kinematics_parameters_file)}"/>
+    <xacro:property name="config_physical_parameters" value="${xacro.load_yaml(physical_parameters_file)}"/>
+    <xacro:property name="config_visual_parameters" value="${xacro.load_yaml(visual_parameters_file)}"/>
 
     <!-- Extract subsections from yaml dictionaries -->
     <xacro:property name="sec_limits" value="${config_joint_limit_parameters['joint_limits']}"/>

--- a/ur_gazebo/config/camera_base.yaml
+++ b/ur_gazebo/config/camera_base.yaml
@@ -1,0 +1,65 @@
+# Camera parameters
+link:
+  name: camera_link
+  length: 0.05
+  radius: 0.005
+  origin: 
+      xyz: 0 0 0
+      rpy: 1.57079632679 0 1.57079632679
+  inertial:
+    mass: 0.01
+    origin: 
+      xyz: 0 0 0
+      rpy: 1.57079632679 0 1.57079632679
+    inertia: 
+      ixx: 0.00001
+      ixy: 0.0
+      ixz: 0.0
+      iyy: 0.000001
+      iyz: 0.0
+      izz: 0.000013
+
+# Modify pitch to control camera tit with -pi/4 straight down, 0 looking at gripper.
+#  XYZ is like tcp with z in grasp direction
+joint:
+  name: camera_joint
+  parent_link: wrist_3_link
+  origin: 
+      xyz: 0 -0.06 0.025
+      rpy: 3.14159265359 -1.32 1.57079632679
+
+camera:
+  name: camera_base
+  pose: 0 0 0 0 0 0
+  update_rate: 15
+  horizontal_fov: 0.78539816339
+  image:
+    width: 800
+    height: 800
+    format: R8G8B8
+  clip:
+    near: 0.02
+    far: 300
+  # Noise is sampled independently per pixel on each frame. 
+  #  That pixel's noise value is added to each of its color
+  #  channels, which at that point lie in the range [0,1]
+  noise_type: gaussian
+  noise_mean: 0
+  noise_stddev: 0.003
+  plugin:
+    # Plugin configuration values from source file at:
+    #  github.com/ros-simulation/gazebo_ros_pkgs/blob/231a7219b36b8a6cdd100b59f66a3df2955df787/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+    always_on: true
+    camera_name: camera_base
+    image_topic_name: image_raw
+    camera_info_topic_name: camera_info
+    cx_prime:      0        # rectified optical center x, for sim, CxPrime == Cx
+    cx:            0        # optical center x
+    cy:            0        # optical center y
+    focal_length:  0        # also known as focal length
+    hack_baseline: 0     # also known as focal length
+    distortion_k1: 0        # linear distortion
+    distortion_k2: 0        # quadratic distortion
+    distortion_k3: 0        # cubic distortion
+    distortion_t1: 0        # tangential distortion
+    distortion_t2: 0        # tangential distortion

--- a/ur_gazebo/config/camera_basler.yaml
+++ b/ur_gazebo/config/camera_basler.yaml
@@ -1,0 +1,67 @@
+# Basler a2A1920-160ucPRO camera inspired parameters
+link:
+  name: camera_link
+  length: 0.05
+  radius: 0.005
+  origin: 
+      xyz: 0 0 0
+      rpy: 1.57079632679 0 1.57079632679
+  inertial:
+    mass: 0.01
+    origin: 
+      xyz: 0 0 0
+      rpy: 1.57079632679 0 1.57079632679
+    inertia: 
+      ixx: 0.00001
+      ixy: 0.0
+      ixz: 0.0
+      iyy: 0.000001
+      iyz: 0.0
+      izz: 0.000013
+
+# Modify pitch (p in rpy) to control camera tit with -pi/4 rad parallel to TCP, and 0 rad perpendicular to TCP.
+#  XYZ is like tcp with z in grasp direction
+joint:
+  name: camera_joint
+  parent_link: wrist_3_link
+  origin: 
+      xyz: 0 -0.06 0.025
+      rpy: 3.14159265359 -1.32 1.57079632679
+
+camera:
+  name: camera_basler
+  pose: 0 0 0 0 0 0
+  update_rate: 15
+  # Horizontal FOV: assuming focal length of 4mm, working distance of 2.9mm, sensor size of 1/2.3"
+  #                 using kowa-lenses online calculator.
+  horizontal_fov: 1.32    # == 75.6°
+  image:
+    width: 1920
+    height: 1080
+    format: B8G8R8
+  clip:
+    near: 0.02
+    far: 300
+  # Noise is sampled independently per pixel on each frame. 
+  #  That pixel's noise value is added to each of its color
+  #  channels, which at that point lie in the range [0,1]
+  noise_type: gaussian
+  noise_mean: 0
+  noise_stddev: 0.003
+  plugin:
+    # Plugin configuration values from source file at:
+    #  github.com/ros-simulation/gazebo_ros_pkgs/blob/231a7219b36b8a6cdd100b59f66a3df2955df787/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+    always_on: true
+    camera_name: camera_basler
+    image_topic_name: image_raw
+    camera_info_topic_name: camera_info
+    cx_prime:      0        # rectified optical center x, for sim, CxPrime == Cx
+    cx:            0        # optical center x
+    cy:            0        # optical center y
+    focal_length:  0        # also known as focal length
+    hack_baseline: 0        # also known as focal length
+    distortion_k1: 0        # linear distortion
+    distortion_k2: 0        # quadratic distortion
+    distortion_k3: 0        # cubic distortion
+    distortion_t1: 0        # tangential distortion
+    distortion_t2: 0        # tangential distortion

--- a/ur_gazebo/config/camera_ximea.yaml
+++ b/ur_gazebo/config/camera_ximea.yaml
@@ -1,0 +1,67 @@
+# Ximea MQ013CG-E2 camera inspired parameters
+link:
+  name: camera_link
+  length: 0.05
+  radius: 0.005
+  origin: 
+      xyz: 0 0 0
+      rpy: 1.57079632679 0 1.57079632679
+  inertial:
+    mass: 0.01
+    origin: 
+      xyz: 0 0 0
+      rpy: 1.57079632679 0 1.57079632679
+    inertia: 
+      ixx: 0.00001
+      ixy: 0.0
+      ixz: 0.0
+      iyy: 0.000001
+      iyz: 0.0
+      izz: 0.000013
+
+# Modify pitch (p in rpy) to control camera tit with -pi/4 rad parallel to TCP, and 0 rad perpendicular to TCP.
+#  XYZ is like tcp with z in grasp direction
+joint:
+  name: camera_joint
+  parent_link: wrist_3_link
+  origin: 
+      xyz: 0 -0.06 0.025
+      rpy: 3.14159265359 -1.32 1.57079632679
+
+camera:
+  name: camera_ximea
+  pose: 0 0 0 0 0 0
+  update_rate: 15
+  # Horizontal FOV: assuming focal length of 4mm, working distance of 2.9mm, sensor size of 1/1.8"
+  #                 using kowa-lenses online calculator.
+  horizontal_fov: 1.47    # == 84°
+  image:
+    width: 1280
+    height: 1024
+    format: B8G8R8
+  clip:
+    near: 0.02
+    far: 300
+  # Noise is sampled independently per pixel on each frame. 
+  #  That pixel's noise value is added to each of its color
+  #  channels, which at that point lie in the range [0,1]
+  noise_type: gaussian
+  noise_mean: 0
+  noise_stddev: 0.003
+  plugin:
+    # Plugin configuration values from source file at:
+    #  github.com/ros-simulation/gazebo_ros_pkgs/blob/231a7219b36b8a6cdd100b59f66a3df2955df787/gazebo_plugins/src/gazebo_ros_camera_utils.cpp
+    always_on: true
+    camera_name: camera_ximea
+    image_topic_name: image_raw
+    camera_info_topic_name: camera_info
+    cx_prime:      0        # rectified optical center x, for sim, CxPrime == Cx
+    cx:            0        # optical center x
+    cy:            0        # optical center y
+    focal_length:  0        # also known as focal length
+    hack_baseline: 0        # also known as focal length
+    distortion_k1: 0        # linear distortion
+    distortion_k2: 0        # quadratic distortion
+    distortion_k3: 0        # cubic distortion
+    distortion_t1: 0        # tangential distortion
+    distortion_t2: 0        # tangential distortion

--- a/ur_gazebo/config/ft_sensor.yaml
+++ b/ur_gazebo/config/ft_sensor.yaml
@@ -1,0 +1,37 @@
+# FT sensor parameters
+link:
+  name: ft_sensor_link
+  length: 0.05
+  radius: 0.035
+  origin: 
+      xyz: 0 0 0.025
+      rpy: 0 0 0
+  inertial:
+    mass: 0.1
+    origin: 
+      xyz: 0 0 0.0125
+      rpy: 0 0 0
+    inertia: 
+      ixx: 0.0001
+      ixy: 0.0
+      ixz: 0.0
+      iyy: 0.00001
+      iyz: 0.0
+      izz: 0.00013
+joint:
+  name: ft_sensor_joint
+  parent_link: wrist_3_link
+  origin: 
+      xyz: 0 0 0
+      rpy: 0 0 0
+sensor:
+  topic_name: ft_sensor/raw_data
+  name: ft_sensor
+  always_on: true
+  visualize: true
+  measure_direction: child_to_parent
+  pose: 0 0 0 0 0 0
+  update_rate: 50
+  noise_type: gaussian
+  noise_mean: 0
+  noise_stddev: 0.003

--- a/ur_gazebo/launch/inc/load_ur.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur.launch.xml
@@ -30,13 +30,12 @@
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />
 
-  <!-- FT sensor choice -->
-  <arg name="use_ft" />
-  <arg unless="$(arg use_ft)" name="xacro_filename" value="ur" />
-  <arg if="$(arg use_ft)" name="xacro_filename" value="ur_ftbasic" />
+  <!-- Sensor configurations -->
+  <arg name="sensor_configs" />
+  <arg name="camera_params" />
 
   <!-- Pass robot description with parameters and configurations -->
-  <param name="robot_description" command="$(find xacro)/xacro '$(find ur_gazebo)/urdf/$(arg xacro_filename).xacro'
+  <param name="robot_description" command="$(find xacro)/xacro '$(find ur_gazebo)/urdf/$(arg sensor_configs).xacro'
     joint_limit_params:=$(arg joint_limit_params)
     kinematics_params:=$(arg kinematics_params)
     physical_params:=$(arg physical_params)
@@ -44,5 +43,7 @@
     transmission_hw_interface:=$(arg transmission_hw_interface)
     safety_limits:=$(arg safety_limits)
     safety_pos_margin:=$(arg safety_pos_margin)
-    safety_k_position:=$(arg safety_k_position)" />
+    safety_k_position:=$(arg safety_k_position)
+    camera_params:=$(find ur_gazebo)/config/$(arg camera_params).yaml" />
+  
 </launch>

--- a/ur_gazebo/launch/inc/load_ur.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur.launch.xml
@@ -33,6 +33,7 @@
   <!-- Sensor configurations -->
   <arg name="sensor_configs" />
   <arg name="camera_params" />
+  <arg name="ft_params" />
 
   <!-- Pass robot description with parameters and configurations -->
   <param name="robot_description" command="$(find xacro)/xacro '$(find ur_gazebo)/urdf/$(arg sensor_configs).xacro'
@@ -44,6 +45,7 @@
     safety_limits:=$(arg safety_limits)
     safety_pos_margin:=$(arg safety_pos_margin)
     safety_k_position:=$(arg safety_k_position)
+    ft_params:='$(find ur_gazebo)/config/$(arg ft_params).yaml'
     camera_params:=$(find ur_gazebo)/config/$(arg camera_params).yaml" />
   
 </launch>

--- a/ur_gazebo/launch/inc/load_ur5e_jointPosition.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur5e_jointPosition.launch.xml
@@ -15,6 +15,7 @@
   <!-- Sensor configurations -->
   <arg name="sensor_configs" />
   <arg name="camera_params" />
+  <arg name="ft_params" />
 
   <!-- Use common launch file and pass all arguments to it -->
   <include file="$(dirname)/load_ur.launch.xml" pass_all_args="true"/>

--- a/ur_gazebo/launch/inc/load_ur5e_jointPosition.launch.xml
+++ b/ur_gazebo/launch/inc/load_ur5e_jointPosition.launch.xml
@@ -12,9 +12,10 @@
   <arg name="safety_pos_margin" default="0.15" doc="The lower/upper limits in the safety controller" />
   <arg name="safety_k_position" default="20" doc="Used to set k position in the safety controller" />
 
-  <!-- FT sensor configuration -->
-  <arg name="use_ft" /> 
-  
+  <!-- Sensor configurations -->
+  <arg name="sensor_configs" />
+  <arg name="camera_params" />
+
   <!-- Use common launch file and pass all arguments to it -->
   <include file="$(dirname)/load_ur.launch.xml" pass_all_args="true"/>
 </launch>

--- a/ur_gazebo/launch/ur5e_bringup_cartesianMotion.launch
+++ b/ur_gazebo/launch/ur5e_bringup_cartesianMotion.launch
@@ -53,6 +53,7 @@
   <!-- Sensor configurations -->
   <arg name="sensor_configs" default="ur_camera"/>
   <arg name="camera_params" default="camera_base"/>
+  <arg name="ft_params" default="ft_sensor"/>
 
   <!-- Load urdf on the parameter server -->
   <include file="$(arg robot_description_file)">
@@ -61,6 +62,7 @@
     <arg name="physical_params" value="$(arg physical_params)"/>
     <arg name="visual_params" value="$(arg visual_params)"/>
     <arg name="camera_params" value="$(arg camera_params)" />
+    <arg name="ft_params" value="$(arg ft_params)" />
     <arg name="sensor_configs" value="$(arg sensor_configs)"/>
   </include>
 

--- a/ur_gazebo/launch/ur5e_bringup_cartesianMotion.launch
+++ b/ur_gazebo/launch/ur5e_bringup_cartesianMotion.launch
@@ -50,8 +50,9 @@
   <arg name="paused" default="true" doc="Starts Gazebo in paused mode" />
   <arg name="gui" default="true" doc="Starts Gazebo gui" />
 
-  <!-- FT sensor configuration -->
-  <arg name="use_ft" default="true" /> 
+  <!-- Sensor configurations -->
+  <arg name="sensor_configs" default="ur_camera"/>
+  <arg name="camera_params" default="camera_base"/>
 
   <!-- Load urdf on the parameter server -->
   <include file="$(arg robot_description_file)">
@@ -59,7 +60,8 @@
     <arg name="kinematics_params" value="$(arg kinematics_params)"/>
     <arg name="physical_params" value="$(arg physical_params)"/>
     <arg name="visual_params" value="$(arg visual_params)"/>
-    <arg name="use_ft" value="$(arg use_ft)" /> 
+    <arg name="camera_params" value="$(arg camera_params)" />
+    <arg name="sensor_configs" value="$(arg sensor_configs)"/>
   </include>
 
   <!-- Robot state publisher -->

--- a/ur_gazebo/urdf/ur_camera.xacro
+++ b/ur_gazebo/urdf/ur_camera.xacro
@@ -1,0 +1,171 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://wiki.ros.org/xacro" name="ur_robot_gazebo">
+  <!--
+    This is a top-level xacro instantiating the Gazebo-specific version of the
+    'ur_robot' macro (ie: 'ur_robot_gazebo') with basic force/torque sensor and passing it values for all its
+    required arguments 
+  -->
+
+  <!--
+    Import main macro.
+
+    NOTE: this imports the Gazebo-wrapper main macro, NOT the regular
+          xacro macro (which is hosted by ur_description).
+  -->
+  <xacro:include filename="$(find ur_gazebo)/urdf/ur_macro.xacro" />
+  <xacro:include filename="$(find ur_description)/urdf/inc/ur_common.xacro" />
+
+  <!--Declare arguments -->
+  <xacro:arg name="joint_limit_params" default="" />
+  <xacro:arg name="physical_params" default="" />
+  <xacro:arg name="kinematics_params" default="" />
+  <xacro:arg name="visual_params" default="" />
+  <xacro:arg name="camera_params" default="" />
+
+  <!--
+    legal values:
+      - hardware_interface/PositionJointInterface
+      - hardware_interface/VelocityJointInterface
+      - hardware_interface/EffortJointInterface
+
+    NOTE: this value must correspond to the controller configured in the
+          controller .yaml files in the 'config' directory.
+  -->
+  <xacro:arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" />
+  <xacro:arg name="safety_limits" default="false" />
+  <xacro:arg name="safety_pos_margin" default="0.15" />
+  <xacro:arg name="safety_k_position" default="20" />
+
+  <!-- Instantiate the Gazebo robot and pass it all the required arguments. -->
+  <xacro:ur_robot_gazebo
+    prefix=""
+    joint_limits_parameters_file="$(arg joint_limit_params)"
+    kinematics_parameters_file="$(arg kinematics_params)"
+    physical_parameters_file="$(arg physical_params)"
+    visual_parameters_file="$(arg visual_params)"
+    transmission_hw_interface="$(arg transmission_hw_interface)"
+    safety_limits="$(arg safety_limits)"
+    safety_pos_margin="$(arg safety_pos_margin)"
+    safety_k_position="$(arg safety_k_position)"
+  />
+  <!--
+     TODO:  add ${prefix} to all following link, joint, and topic names, and resolve
+   -->
+  <!--
+    Attach the Gazebo model to Gazebo's world frame.
+
+    Note: if you're looking to integrate a UR into a larger scene and need
+    to add EEFs or other parts, DO NOT change this file or the 'world' link
+    here. Create a NEW xacro instead and decide whether you need to add
+    a 'world' link there.
+  -->
+  <link name="world" />
+  <joint name="world_joint" type="fixed">
+    <parent link="world" />
+    <child link="base_link" />
+    <origin xyz="0 0 0" rpy="0 0 0" />
+  </joint>
+
+  <!-- 
+    Camera sensor link, joint, and Gazebo definition
+   -->
+   <xacro:property name="camera_configs" value="${xacro.load_yaml('$(arg camera_params)')}"/>
+
+   <link name="${camera_configs['link']['name']}">
+    <visual>
+      <origin 
+        xyz="${camera_configs['link']['origin']['xyz']}"
+        rpy="${camera_configs['link']['origin']['rpy']}" />
+      <geometry>
+        <cylinder 
+          radius="${camera_configs['link']['radius']}" 
+          length="${camera_configs['link']['length']}" />
+      </geometry>
+    </visual>
+    <collision>
+      <origin 
+        xyz="${camera_configs['link']['origin']['xyz']}"
+        rpy="${camera_configs['link']['origin']['rpy']}" />
+      <geometry>
+        <cylinder 
+          radius="${camera_configs['link']['radius']}" 
+          length="${camera_configs['link']['length']}" />
+      </geometry>
+    </collision>
+    <inertial>
+      <mass value="${camera_configs['link']['inertial']['mass']}" />
+      <origin 
+        xyz="${camera_configs['link']['inertial']['origin']['xyz']}"
+        rpy="${camera_configs['link']['inertial']['origin']['rpy']}" />
+      <inertia
+        ixx="${camera_configs['link']['inertial']['inertia']['ixx']}"
+        ixy="${camera_configs['link']['inertial']['inertia']['ixy']}"
+        ixz="${camera_configs['link']['inertial']['inertia']['ixz']}"
+        iyy="${camera_configs['link']['inertial']['inertia']['iyy']}"
+        iyz="${camera_configs['link']['inertial']['inertia']['iyz']}"
+        izz="${camera_configs['link']['inertial']['inertia']['izz']}" />
+    </inertial>
+  </link>
+
+  <joint name="${camera_configs['joint']['name']}" type="revolute">
+    <parent link="${camera_configs['joint']['parent_link']}" />
+    <child link="${camera_configs['link']['name']}" />
+    <origin 
+        xyz="${camera_configs['joint']['origin']['xyz']}"
+        rpy="${camera_configs['joint']['origin']['rpy']}" />
+    <axis xyz="0 0 1" />
+    <limit lower="0" upper="0" effort="0" velocity="0" />
+    <dynamics damping="0" friction="0" />
+  </joint>
+  
+  <!-- Disable collision with previous link -->
+  <disable_collisions 
+    link1="${camera_configs['link']['name']}"
+    link2="${camera_configs['joint']['parent_link']}"
+    reason="Adjacent" />
+
+  <gazebo
+    reference="${camera_configs['link']['name']}"
+    pose="${camera_configs['camera']['pose']}">
+    <sensor 
+      type="camera"
+      name="${camera_configs['camera']['name']}">
+      <update_rate>${camera_configs['camera']['update_rate']}</update_rate>
+      <camera
+        name="head" >
+        <horizontal_fov>${camera_configs['camera']['horizontal_fov']}</horizontal_fov>
+        <image> 
+          <width>${camera_configs['camera']['image']['width']}</width>
+          <height>${camera_configs['camera']['image']['height']}</height>
+          <format>${camera_configs['camera']['image']['format']}</format>
+        </image>
+        <clip> 
+          <near>${camera_configs['camera']['clip']['near']}</near>
+          <far>${camera_configs['camera']['clip']['far']}</far>
+        </clip>
+        <noise>
+          <type>${camera_configs['camera']['noise_type']}</type> 
+          <mean>${camera_configs['camera']['noise_mean']}</mean> 
+          <stddev>${camera_configs['camera']['noise_stddev']}</stddev>
+        </noise>
+      </camera>
+      <plugin name="${camera_configs['camera']['plugin']['camera_name']}_controller" filename="libgazebo_ros_camera.so">
+        <alwaysOn>${camera_configs['camera']['plugin']['always_on']}</alwaysOn>
+        <cameraName>${camera_configs['camera']['plugin']['camera_name']}</cameraName>
+        <imageTopicName>${camera_configs['camera']['plugin']['image_topic_name']}</imageTopicName>
+        <cameraInfoTopicName>${camera_configs['camera']['plugin']['camera_info_topic_name']}</cameraInfoTopicName>
+        <frameName>${camera_configs['link']['name']}</frameName>
+        <CxPrime>${camera_configs['camera']['plugin']['cx_prime']}</CxPrime>
+        <Cx>${camera_configs['camera']['plugin']['cx']}</Cx>
+        <Cy>${camera_configs['camera']['plugin']['cy']}</Cy>
+        <focalLength>${camera_configs['camera']['plugin']['focal_length']}</focalLength>
+        <hackBaseline>${camera_configs['camera']['plugin']['hack_baseline']}</hackBaseline>
+        <distortionK1>${camera_configs['camera']['plugin']['distortion_k1']}</distortionK1>
+        <distortionK2>${camera_configs['camera']['plugin']['distortion_k2']}</distortionK2>
+        <distortionK3>${camera_configs['camera']['plugin']['distortion_k3']}</distortionK3>
+        <distortionT1>${camera_configs['camera']['plugin']['distortion_t1']}</distortionT1>
+        <distortionT2>${camera_configs['camera']['plugin']['distortion_t2']}</distortionT2>
+      </plugin>
+    </sensor>
+  </gazebo>
+</robot>

--- a/ur_gazebo/urdf/ur_ft.xacro
+++ b/ur_gazebo/urdf/ur_ft.xacro
@@ -20,6 +20,7 @@
   <xacro:arg name="physical_params" default="" />
   <xacro:arg name="kinematics_params" default="" />
   <xacro:arg name="visual_params" default="" />
+  <xacro:arg name="ft_params" default="" />
 
   <!--
     legal values:
@@ -58,69 +59,87 @@
 
   <!-- 
     Force torque sensor link, joint, and Gazebo definition
-    TODO:  parameterize FT sensor properties, e.g. choose Optoforce or OnRobotics by YAML 
   -->
+  <xacro:property name="ft_config" value="${xacro.load_yaml('$(arg ft_params)')}"/>
 
-  <link name="ft_sensor_link">
+  <link name="${ft_config['link']['name']}">
     <visual>
-      <origin rpy="0 0 0" xyz="0 0 0.025" />
+      <origin 
+        xyz="${ft_config['link']['origin']['xyz']}"
+        rpy="${ft_config['link']['origin']['rpy']}" />
       <geometry>
-        <cylinder radius="0.035" length="0.05" />
+        <cylinder 
+          radius="${ft_config['link']['radius']}" 
+          length="${ft_config['link']['length']}" />
       </geometry>
-      <material name="LightGrey">
-        <color rgba="0.7 0.7 0.7 1.0" />
-      </material>
     </visual>
     <collision>
-      <origin rpy="0 0 0" xyz="0 0 0.025" />
+      <origin 
+        xyz="${ft_config['link']['origin']['xyz']}"
+        rpy="${ft_config['link']['origin']['rpy']}" />
       <geometry>
-        <cylinder radius="0.035" length="0.05" />
+        <cylinder 
+          radius="${ft_config['link']['radius']}" 
+          length="${ft_config['link']['length']}" />
       </geometry>
     </collision>
     <inertial>
-      <mass value="0.100" />
-      <origin rpy="0 0 0" xyz="0.0 0.0 0.025" />
-      <inertia ixx="9.890410052167731e-05" ixy="0.0" ixz="0.0" iyy="9.890410052167731e-05" iyz="0.0" izz="0.0001321171875" />
+      <mass value="${ft_config['link']['inertial']['mass']}" />
+      <origin 
+        xyz="${ft_config['link']['inertial']['origin']['xyz']}"
+        rpy="${ft_config['link']['inertial']['origin']['rpy']}" />
+      <inertia
+        ixx="${ft_config['link']['inertial']['inertia']['ixx']}"
+        ixy="${ft_config['link']['inertial']['inertia']['ixy']}"
+        ixz="${ft_config['link']['inertial']['inertia']['ixz']}"
+        iyy="${ft_config['link']['inertial']['inertia']['iyy']}"
+        iyz="${ft_config['link']['inertial']['inertia']['iyz']}"
+        izz="${ft_config['link']['inertial']['inertia']['izz']}" />
     </inertial>
   </link>
 
   <!-- Use revolute joint as Gazebo's internal URDF to SRDF convertion lumps fixed links in parent -->
-  <joint name="ft_sensor_joint" type="revolute">
-    <parent link="wrist_3_link" />
-    <child link="ft_sensor_link" />
-    <origin xyz="0 0 0.001" rpy="0 0 0" />
+  <joint name="${ft_config['joint']['name']}" type="revolute">
+    <parent link="${ft_config['joint']['parent_link']}" />
+    <child link="${ft_config['link']['name']}" />
+    <origin 
+        xyz="${ft_config['joint']['origin']['xyz']}"
+        rpy="${ft_config['joint']['origin']['rpy']}" />
     <axis xyz="0 0 1" />
     <limit lower="0" upper="0" effort="0" velocity="0" />
     <dynamics damping="0" friction="0" />
   </joint>
 
   <!-- Disable collision with previous link -->
-  <disable_collisions link1="ft_sensor_link" link2="wrist_3_link" reason="Adjacent" />
+  <disable_collisions
+    link1="${ft_config['link']['name']}"
+    link2="${ft_config['joint']['parent_link']}"
+    reason="Adjacent" />
 
   <!-- Enable Gazebo sensor on joint -->
-  <gazebo reference="ft_sensor_joint">
-    <pose>0 0 0 0 0 0</pose>
+  <gazebo 
+    reference="${ft_config['joint']['name']}"
+    pose="${ft_config['sensor']['pose']}"
+    update_rate="${ft_config['sensor']['update_rate']}">
     <sensor name="ft_sensor" type="force_torque">
-      <always_on>true</always_on>
-      <update_rate>10.0</update_rate>
-      <visualize>true</visualize>
+      <always_on>${ft_config['sensor']['always_on']}</always_on>
+      <visualize>${ft_config['sensor']['visualize']}</visualize>
       <force_torque>
         <frame>sensor</frame>
-        <measure_direction>child_to_parent</measure_direction>
+        <measure_direction>${ft_config['sensor']['measure_direction']}</measure_direction>
       </force_torque>
     </sensor>
   </gazebo>
 
   <!-- Use gazebo_ros_pkgs ft_sensor library to publish ft_sensor_topic by referencing ft_sensor_joint -->
   <gazebo>
-    <plugin name="ft_sensor_plugin" filename="libgazebo_ros_ft_sensor.so">
-      <topicName>ft_sensor/ft_sensor_topic</topicName>
-      <jointName>ft_sensor_joint</jointName>
-      <noise>
-        <type>gaussian</type>
-        <mean>0.0</mean>
-        <stddev>0.003</stddev> <!-- change this to simulate noise -->
-      </noise>
+    <plugin name="${ft_config['sensor']['name']}_plugin" filename="libgazebo_ros_ft_sensor.so">
+      <topicName>${ft_config['sensor']['topic_name']}</topicName>
+      <jointName>${ft_config['joint']['name']}</jointName>
+      <noise 
+        type="${ft_config['sensor']['noise_type']}" 
+        mean="${ft_config['sensor']['noise_mean']}" 
+        stddev="${ft_config['sensor']['noise_stddev']}" />
     </plugin>
   </gazebo>
 </robot>

--- a/ur_gazebo/urdf/ur_ft_camera.xacro
+++ b/ur_gazebo/urdf/ur_ft_camera.xacro
@@ -1,0 +1,256 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://wiki.ros.org/xacro" name="ur_robot_gazebo">
+  <!--
+    This is a top-level xacro instantiating the Gazebo-specific version of the
+    'ur_robot' macro (ie: 'ur_robot_gazebo') with basic force/torque sensor and passing it values for all its
+    required arguments 
+  -->
+
+  <!--
+    Import main macro.
+
+    NOTE: this imports the Gazebo-wrapper main macro, NOT the regular
+          xacro macro (which is hosted by ur_description).
+  -->
+  <xacro:include filename="$(find ur_gazebo)/urdf/ur_macro.xacro" />
+  <xacro:include filename="$(find ur_description)/urdf/inc/ur_common.xacro" />
+
+  <!--Declare arguments -->
+  <xacro:arg name="joint_limit_params" default="" />
+  <xacro:arg name="physical_params" default="" />
+  <xacro:arg name="kinematics_params" default="" />
+  <xacro:arg name="visual_params" default="" />
+  <xacro:arg name="ft_params" default="" />
+  <xacro:arg name="camera_params" default="" />
+
+  <!--
+    legal values:
+      - hardware_interface/PositionJointInterface
+      - hardware_interface/VelocityJointInterface
+      - hardware_interface/EffortJointInterface
+
+    NOTE: this value must correspond to the controller configured in the
+          controller .yaml files in the 'config' directory.
+  -->
+  <xacro:arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" />
+  <xacro:arg name="safety_limits" default="false" />
+  <xacro:arg name="safety_pos_margin" default="0.15" />
+  <xacro:arg name="safety_k_position" default="20" />
+
+  <!-- Instantiate the Gazebo robot and pass it all the required arguments. -->
+  <xacro:ur_robot_gazebo
+    prefix=""
+    joint_limits_parameters_file="$(arg joint_limit_params)"
+    kinematics_parameters_file="$(arg kinematics_params)"
+    physical_parameters_file="$(arg physical_params)"
+    visual_parameters_file="$(arg visual_params)"
+    transmission_hw_interface="$(arg transmission_hw_interface)"
+    safety_limits="$(arg safety_limits)"
+    safety_pos_margin="$(arg safety_pos_margin)"
+    safety_k_position="$(arg safety_k_position)"
+  />
+  <!--
+     TODO:  add ${prefix} to all following link, joint, and topic names, and resolve
+   -->
+  <!--
+    Attach the Gazebo model to Gazebo's world frame.
+
+    Note: if you're looking to integrate a UR into a larger scene and need
+    to add EEFs or other parts, DO NOT change this file or the 'world' link
+    here. Create a NEW xacro instead and decide whether you need to add
+    a 'world' link there.
+  -->
+  <link name="world" />
+  <joint name="world_joint" type="fixed">
+    <parent link="world" />
+    <child link="base_link" />
+    <origin xyz="0 0 0" rpy="0 0 0" />
+  </joint>
+  <!-- 
+    Force torque sensor link, joint, and Gazebo definition
+  -->
+  <xacro:property name="ft_config" value="${xacro.load_yaml('$(arg ft_params)')}"/>
+
+  <link name="${ft_config['link']['name']}">
+    <visual>
+      <origin 
+        xyz="${ft_config['link']['origin']['xyz']}"
+        rpy="${ft_config['link']['origin']['rpy']}" />
+      <geometry>
+        <cylinder 
+          radius="${ft_config['link']['radius']}" 
+          length="${ft_config['link']['length']}" />
+      </geometry>
+    </visual>
+    <collision>
+      <origin 
+        xyz="${ft_config['link']['origin']['xyz']}"
+        rpy="${ft_config['link']['origin']['rpy']}" />
+      <geometry>
+        <cylinder 
+          radius="${ft_config['link']['radius']}" 
+          length="${ft_config['link']['length']}" />
+      </geometry>
+    </collision>
+    <inertial>
+      <mass value="${ft_config['link']['inertial']['mass']}" />
+      <origin 
+        xyz="${ft_config['link']['inertial']['origin']['xyz']}"
+        rpy="${ft_config['link']['inertial']['origin']['rpy']}" />
+      <inertia
+        ixx="${ft_config['link']['inertial']['inertia']['ixx']}"
+        ixy="${ft_config['link']['inertial']['inertia']['ixy']}"
+        ixz="${ft_config['link']['inertial']['inertia']['ixz']}"
+        iyy="${ft_config['link']['inertial']['inertia']['iyy']}"
+        iyz="${ft_config['link']['inertial']['inertia']['iyz']}"
+        izz="${ft_config['link']['inertial']['inertia']['izz']}" />
+    </inertial>
+  </link>
+
+  <!-- Use revolute joint as Gazebo's internal URDF to SRDF convertion lumps fixed links in parent -->
+  <joint name="${ft_config['joint']['name']}" type="revolute">
+    <parent link="${ft_config['joint']['parent_link']}" />
+    <child link="${ft_config['link']['name']}" />
+    <origin 
+        xyz="${ft_config['joint']['origin']['xyz']}"
+        rpy="${ft_config['joint']['origin']['rpy']}" />
+    <axis xyz="0 0 1" />
+    <limit lower="0" upper="0" effort="0" velocity="0" />
+    <dynamics damping="0" friction="0" />
+  </joint>
+
+  <!-- Disable collision with previous link -->
+  <disable_collisions
+    link1="${ft_config['link']['name']}"
+    link2="${ft_config['joint']['parent_link']}"
+    reason="Adjacent" />
+
+  <!-- Enable Gazebo sensor on joint -->
+  <gazebo 
+    reference="${ft_config['joint']['name']}"
+    pose="${ft_config['sensor']['pose']}"
+    update_rate="${ft_config['sensor']['update_rate']}">
+    <sensor name="ft_sensor" type="force_torque">
+      <always_on>${ft_config['sensor']['always_on']}</always_on>
+      <visualize>${ft_config['sensor']['visualize']}</visualize>
+      <force_torque>
+        <frame>sensor</frame>
+        <measure_direction>${ft_config['sensor']['measure_direction']}</measure_direction>
+      </force_torque>
+    </sensor>
+  </gazebo>
+
+  <!-- Use gazebo_ros_pkgs ft_sensor library to publish ft_sensor_topic by referencing ft_sensor_joint -->
+  <gazebo>
+    <plugin name="${ft_config['sensor']['name']}_plugin" filename="libgazebo_ros_ft_sensor.so">
+      <topicName>${ft_config['sensor']['topic_name']}</topicName>
+      <jointName>${ft_config['joint']['name']}</jointName>
+      <noise 
+        type="${ft_config['sensor']['noise_type']}" 
+        mean="${ft_config['sensor']['noise_mean']}" 
+        stddev="${ft_config['sensor']['noise_stddev']}" />
+    </plugin>
+  </gazebo>
+  <!-- 
+    Camera link, joint, and Gazebo definition
+   -->
+   <xacro:property name="camera_config" value="${xacro.load_yaml('$(arg camera_params)')}"/>
+
+   <link name="${camera_config['link']['name']}">
+    <visual>
+      <origin 
+        xyz="${camera_config['link']['origin']['xyz']}"
+        rpy="${camera_config['link']['origin']['rpy']}" />
+      <geometry>
+        <cylinder 
+          radius="${camera_config['link']['radius']}" 
+          length="${camera_config['link']['length']}" />
+      </geometry>
+    </visual>
+    <collision>
+      <origin 
+        xyz="${camera_config['link']['origin']['xyz']}"
+        rpy="${camera_config['link']['origin']['rpy']}" />
+      <geometry>
+        <cylinder 
+          radius="${camera_config['link']['radius']}" 
+          length="${camera_config['link']['length']}" />
+      </geometry>
+    </collision>
+    <inertial>
+      <mass value="${camera_config['link']['inertial']['mass']}" />
+      <origin 
+        xyz="${camera_config['link']['inertial']['origin']['xyz']}"
+        rpy="${camera_config['link']['inertial']['origin']['rpy']}" />
+      <inertia
+        ixx="${camera_config['link']['inertial']['inertia']['ixx']}"
+        ixy="${camera_config['link']['inertial']['inertia']['ixy']}"
+        ixz="${camera_config['link']['inertial']['inertia']['ixz']}"
+        iyy="${camera_config['link']['inertial']['inertia']['iyy']}"
+        iyz="${camera_config['link']['inertial']['inertia']['iyz']}"
+        izz="${camera_config['link']['inertial']['inertia']['izz']}" />
+    </inertial>
+  </link>
+
+  <joint name="${camera_config['joint']['name']}" type="revolute">
+    <parent link="${camera_config['joint']['parent_link']}" />
+    <child link="${camera_config['link']['name']}" />
+    <origin 
+        xyz="${camera_config['joint']['origin']['xyz']}"
+        rpy="${camera_config['joint']['origin']['rpy']}" />
+    <axis xyz="0 0 1" />
+    <limit lower="0" upper="0" effort="0" velocity="0" />
+    <dynamics damping="0" friction="0" />
+  </joint>
+  
+  <!-- Disable collision with previous link -->
+  <disable_collisions 
+    link1="${camera_config['link']['name']}"
+    link2="${camera_config['joint']['parent_link']}"
+    reason="Adjacent" />
+
+  <gazebo
+    reference="${camera_config['link']['name']}"
+    pose="${camera_config['camera']['pose']}">
+    <sensor 
+      type="camera"
+      name="camera1 ">
+      <update_rate>${camera_config['camera']['update_rate']}</update_rate>
+      <camera
+        name="head" >
+        <horizontal_fov>${camera_config['camera']['horizontal_fov']}</horizontal_fov>
+        <image> 
+          <width>${camera_config['camera']['image']['width']}</width>
+          <height>${camera_config['camera']['image']['height']}</height>
+          <format>${camera_config['camera']['image']['format']}</format>
+        </image>
+        <clip> 
+          <near>${camera_config['camera']['clip']['near']}</near>
+          <far>${camera_config['camera']['clip']['far']}</far>
+        </clip>
+        <noise>
+          <type>${camera_config['camera']['noise_type']}</type> 
+          <mean>${camera_config['camera']['noise_mean']}</mean> 
+          <stddev>${camera_config['camera']['noise_stddev']}</stddev>
+        </noise>
+      </camera>
+      <plugin name="${camera_config['camera']['plugin']['camera_name']}_controller" filename="libgazebo_ros_camera.so">
+        <alwaysOn>${camera_config['camera']['plugin']['always_on']}</alwaysOn>
+        <cameraName>${camera_config['camera']['plugin']['camera_name']}</cameraName>
+        <imageTopicName>${camera_config['camera']['plugin']['image_topic_name']}</imageTopicName>
+        <cameraInfoTopicName>${camera_config['camera']['plugin']['camera_info_topic_name']}</cameraInfoTopicName>
+        <frameName>${camera_config['link']['name']}</frameName>
+        <CxPrime>${camera_config['camera']['plugin']['cx_prime']}</CxPrime>
+        <Cx>${camera_config['camera']['plugin']['cx']}</Cx>
+        <Cy>${camera_config['camera']['plugin']['cy']}</Cy>
+        <focalLength>${camera_config['camera']['plugin']['focal_length']}</focalLength>
+        <hackBaseline>${camera_config['camera']['plugin']['hack_baseline']}</hackBaseline>
+        <distortionK1>${camera_config['camera']['plugin']['distortion_k1']}</distortionK1>
+        <distortionK2>${camera_config['camera']['plugin']['distortion_k2']}</distortionK2>
+        <distortionK3>${camera_config['camera']['plugin']['distortion_k3']}</distortionK3>
+        <distortionT1>${camera_config['camera']['plugin']['distortion_t1']}</distortionT1>
+        <distortionT2>${camera_config['camera']['plugin']['distortion_t2']}</distortionT2>
+      </plugin>
+    </sensor>
+  </gazebo>
+</robot>


### PR DESCRIPTION
Added 2D cameras with similar parameters to Ximea, and Basler cameras we use, as well as a base camera.
Two new Xacro files are added to allow additional options for the user to give a launch argument to launch the Gazebo UR robot with either the camera only `sensor_configs:=ur_camera`, or by default the camera and FT sensor `sensor_configs:=ur_ft_camera`. User can also launch FT sensor only with `sensor_configs:=ur_ft`.

We use YAML files to specifiy the camera configuration, which allows easy editing of the parameters. Three files are provided, `camera_base.yaml`, `camera_ximea.yaml`, and `camera_basler.yaml`. The user can specify by providing launch argument `camera_params:=camera_base` for example.

Finally, the implementation is reflected upon the previous implementation of the FT sensor; now it has its own YAML file as well.

This addresses ticket `MPD-2398`.