### PR TITLE
Add M-Picking Scene

### DIFF
--- a/ur_gazebo/config/camera_base.yaml
+++ b/ur_gazebo/config/camera_base.yaml
@@ -1,8 +1,8 @@
 # Camera parameters
 link:
   name: camera_link
-  length: 0.05
-  radius: 0.005
+  length: 0.03
+  radius: 0.008
   origin: 
       xyz: 0 0 0
       rpy: 1.57079632679 0 1.57079632679
@@ -19,20 +19,20 @@ link:
       iyz: 0.0
       izz: 0.000013
 
-# Modify pitch to control camera tit with -pi/4 straight down, 0 looking at gripper.
+# Modify pitch to control camera tit with -pi/2 (~-1.5708) straight down, 0 looking at gripper.
 #  XYZ is like tcp with z in grasp direction
 joint:
   name: camera_joint
   parent_link: wrist_3_link
   origin: 
       xyz: 0 -0.06 0.025
-      rpy: 3.14159265359 -1.32 1.57079632679
+      rpy: 3.14159265359 -1.2 1.57079632679
 
 camera:
   name: camera_base
   pose: 0 0 0 0 0 0
   update_rate: 30
-  horizontal_fov: 0.78539816339
+  horizontal_fov: 1.1
   image:
     width: 800
     height: 800

--- a/ur_gazebo/config/ft_sensor.yaml
+++ b/ur_gazebo/config/ft_sensor.yaml
@@ -1,10 +1,10 @@
 # FT sensor parameters
 link:
   name: ft_sensor_link
-  length: 0.05
+  length: 0.03
   radius: 0.035
   origin: 
-      xyz: 0 0 0.025
+      xyz: 0 0 0
       rpy: 0 0 0
   inertial:
     mass: 0.1
@@ -22,7 +22,7 @@ joint:
   name: ft_sensor_joint
   parent_link: wrist_3_link
   origin: 
-      xyz: 0 0 0
+      xyz: 0 0 0.015  # z = half of length
       rpy: 0 0 0
 sensor:
   topic_name: ft_sensor/raw_data

--- a/ur_gazebo/launch/inc/ur_control.launch.xml
+++ b/ur_gazebo/launch/inc/ur_control.launch.xml
@@ -23,6 +23,7 @@
   <!-- Gazebo parameters -->
   <arg name="gazebo_model_name" default="robot" doc="The name to give to the model in Gazebo (after spawning it)." />
   <arg name="gazebo_world" default="worlds/empty.world" doc="The '.world' file to load in Gazebo." />
+  <arg name="gazebo_world_launch" default="$(find gazebo_ros)/launch/empty_world.launch" doc="The '.launch' file to load Gazebo" />
   <arg name="gui" default="true" doc="If true, Gazebo UI is started. If false, only start Gazebo server." />
   <arg name="paused" default="false" doc="If true, start Gazebo in paused mode. If false, start simulation as soon as Gazebo has loaded." />
   <arg name="robot_description_param_name" default="robot_description" doc="Name of the parameter which contains the robot description (ie: URDF) which should be spawned into Gazebo." />
@@ -46,7 +47,7 @@
   <rosparam file="$(arg controller_config_file)" command="load"/>
 
   <!-- Start Gazebo and load the empty world if requested to do so -->
-  <include file="$(find gazebo_ros)/launch/empty_world.launch" if="$(arg start_gazebo)">
+  <include file="$(arg gazebo_world_launch)" if="$(arg start_gazebo)">
     <arg name="world_name" value="$(arg gazebo_world)"/>
     <arg name="paused" value="$(arg paused)"/>
     <arg name="gui" value="$(arg gui)"/>

--- a/ur_gazebo/launch/ur5e_bringup_cartesianMotion.launch
+++ b/ur_gazebo/launch/ur5e_bringup_cartesianMotion.launch
@@ -37,6 +37,16 @@
   <arg name="physical_params" default="$(find ur_description)/config/ur5e/physical_parameters.yaml"/>
   <arg name="visual_params" default="$(find ur_description)/config/ur5e/visual_parameters.yaml"/>
 
+  <!-- World configuration:
+    As more worlds are designed, they will be made available (through m_picking
+    parameter) here. By default, we launch an empty world. Or we launch a user
+    defined skill_scenario.
+  -->
+  <arg name="skill_scenario" default="empty"/>
+  <arg name="gazebo_world_launch" default="$(find gazebo_ros)/launch/empty_world.launch" />
+  <arg name="gazebo_world" value="worlds/empty.world" if="$(eval arg('skill_scenario')=='empty')"/>
+  <arg name="gazebo_world" value="$(find micropsi_packages)/worlds/m_picking/lab.world" if="$(eval arg('skill_scenario')=='m_picking')"/>
+
   <!-- Controller configuration -->
   <arg name="controller_config_file" default="$(find ur_gazebo)/config/ur5e_controllers.yaml" doc="Config file used for defining the ROS-Control controllers."/>
   <arg name="controllers" default="joint_state_controller pos_joint_traj_controller" doc="Controllers that are activated by default."/>
@@ -51,7 +61,8 @@
   <arg name="gui" default="true" doc="Starts Gazebo gui" />
 
   <!-- Sensor configurations -->
-  <arg name="sensor_configs" default="ur_ft_camera"/>
+  <arg name="sensor_configs" value="ur_ft_camera" if="$(eval arg('skill_scenario')=='empty')" />
+  <arg name="sensor_configs" value="ur_ft_camera_m-gripper" if="$(eval arg('skill_scenario')=='m_picking')"/>
   <arg name="camera_params" default="camera_base"/>
   <arg name="ft_params" default="ft_sensor"/>
 
@@ -76,6 +87,8 @@
   <include file="$(dirname)/inc/ur_control.launch.xml">
     <arg name="controller_config_file" value="$(arg controller_config_file)"/>
     <arg name="controllers" value="$(arg controllers)"/>
+    <arg name="gazebo_world" value="$(arg gazebo_world)" />
+    <arg name="gazebo_world_launch" value="$(arg gazebo_world_launch)" />
     <arg name="gui" value="$(arg gui)"/>
     <arg name="paused" value="$(arg paused)"/>
     <arg name="stopped_controllers" value="$(arg stopped_controllers)"/>

--- a/ur_gazebo/launch/ur5e_bringup_cartesianMotion.launch
+++ b/ur_gazebo/launch/ur5e_bringup_cartesianMotion.launch
@@ -39,8 +39,8 @@
 
   <!-- Controller configuration -->
   <arg name="controller_config_file" default="$(find ur_gazebo)/config/ur5e_controllers.yaml" doc="Config file used for defining the ROS-Control controllers."/>
-  <arg name="controllers" default="joint_state_controller fzi_cartesian_motion_controller" doc="Controllers that are activated by default."/>
-  <arg name="stopped_controllers" default="pos_joint_traj_controller joint_group_pos_controller" doc="Controllers that are initally loaded, but not started."/>
+  <arg name="controllers" default="joint_state_controller pos_joint_traj_controller" doc="Controllers that are activated by default."/>
+  <arg name="stopped_controllers" default="fzi_cartesian_motion_controller joint_group_pos_controller" doc="Controllers that are initally loaded, but not started."/>
 
   <!-- robot_state_publisher configuration -->
   <arg name="tf_prefix" default="" doc="tf_prefix used for the robot."/>

--- a/ur_gazebo/urdf/ur_ft_camera_m-gripper.xacro
+++ b/ur_gazebo/urdf/ur_ft_camera_m-gripper.xacro
@@ -1,0 +1,302 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://wiki.ros.org/xacro" name="ur_robot_gazebo">
+  <!--
+    This is a top-level xacro instantiating the Gazebo-specific version of the
+    'ur_robot' macro (ie: 'ur_robot_gazebo') with basic force/torque sensor and passing it values for all its
+    required arguments 
+  -->
+
+  <!--
+    Import main macro.
+
+    NOTE: this imports the Gazebo-wrapper main macro, NOT the regular
+          xacro macro (which is hosted by ur_description).
+  -->
+  <xacro:include filename="$(find ur_gazebo)/urdf/ur_macro.xacro" />
+  <xacro:include filename="$(find ur_description)/urdf/inc/ur_common.xacro" />
+
+  <!--Declare arguments -->
+  <xacro:arg name="joint_limit_params" default="" />
+  <xacro:arg name="physical_params" default="" />
+  <xacro:arg name="kinematics_params" default="" />
+  <xacro:arg name="visual_params" default="" />
+  <xacro:arg name="ft_params" default="" />
+  <xacro:arg name="camera_params" default="" />
+
+  <!--
+    legal values:
+      - hardware_interface/PositionJointInterface
+      - hardware_interface/VelocityJointInterface
+      - hardware_interface/EffortJointInterface
+
+    NOTE: this value must correspond to the controller configured in the
+          controller .yaml files in the 'config' directory.
+  -->
+  <xacro:arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface" />
+  <xacro:arg name="safety_limits" default="false" />
+  <xacro:arg name="safety_pos_margin" default="0.15" />
+  <xacro:arg name="safety_k_position" default="20" />
+
+  <!-- Instantiate the Gazebo robot and pass it all the required arguments. -->
+  <xacro:ur_robot_gazebo
+    prefix=""
+    joint_limits_parameters_file="$(arg joint_limit_params)"
+    kinematics_parameters_file="$(arg kinematics_params)"
+    physical_parameters_file="$(arg physical_params)"
+    visual_parameters_file="$(arg visual_params)"
+    transmission_hw_interface="$(arg transmission_hw_interface)"
+    safety_limits="$(arg safety_limits)"
+    safety_pos_margin="$(arg safety_pos_margin)"
+    safety_k_position="$(arg safety_k_position)"
+  />
+  <!--
+     TODO:  add ${prefix} to all following link, joint, and topic names, and resolve
+   -->
+  <!--
+    Attach the Gazebo model to Gazebo's world frame.
+
+    Note: if you're looking to integrate a UR into a larger scene and need
+    to add EEFs or other parts, DO NOT change this file or the 'world' link
+    here. Create a NEW xacro instead and decide whether you need to add
+    a 'world' link there.
+  -->
+  <link name="world" />
+  <joint name="world_joint" type="fixed">
+    <parent link="world" />
+    <child link="base_link" />
+    <origin xyz="0.0 1.0 0.98" rpy="0 0 0" />
+  </joint>
+
+  <!-- 
+    Force torque sensor link, joint, and Gazebo settings
+  -->
+  <xacro:property name="ft_config" value="${xacro.load_yaml('$(arg ft_params)')}"/>
+  <!-- FT sensor link -->
+  <link name="${ft_config['link']['name']}">
+    <visual>
+      <origin 
+        xyz="${ft_config['link']['origin']['xyz']}"
+        rpy="${ft_config['link']['origin']['rpy']}" />
+      <geometry>
+        <cylinder 
+          radius="${ft_config['link']['radius']}" 
+          length="${ft_config['link']['length']}" />
+      </geometry>
+    </visual>
+    <collision>
+      <origin 
+        xyz="${ft_config['link']['origin']['xyz']}"
+        rpy="${ft_config['link']['origin']['rpy']}" />
+      <geometry>
+        <cylinder 
+          radius="${ft_config['link']['radius']}" 
+          length="${ft_config['link']['length']}" />
+      </geometry>
+    </collision>
+    <inertial>
+      <mass value="${ft_config['link']['inertial']['mass']}" />
+      <origin 
+        xyz="${ft_config['link']['inertial']['origin']['xyz']}"
+        rpy="${ft_config['link']['inertial']['origin']['rpy']}" />
+      <inertia
+        ixx="${ft_config['link']['inertial']['inertia']['ixx']}"
+        ixy="${ft_config['link']['inertial']['inertia']['ixy']}"
+        ixz="${ft_config['link']['inertial']['inertia']['ixz']}"
+        iyy="${ft_config['link']['inertial']['inertia']['iyy']}"
+        iyz="${ft_config['link']['inertial']['inertia']['iyz']}"
+        izz="${ft_config['link']['inertial']['inertia']['izz']}" />
+    </inertial>
+  </link>
+  <!-- FT sensor joint -->
+  <!-- Use revolute joint as Gazebo's internal URDF to SRDF convertion lumps fixed links in parent -->
+  <joint name="${ft_config['joint']['name']}" type="revolute">
+    <parent link="${ft_config['joint']['parent_link']}" />
+    <child link="${ft_config['link']['name']}" />
+    <origin 
+        xyz="${ft_config['joint']['origin']['xyz']}"
+        rpy="${ft_config['joint']['origin']['rpy']}" />
+    <axis xyz="0 0 1" />
+    <limit lower="0" upper="0" effort="0" velocity="0" />
+    <dynamics damping="0" friction="0" />
+  </joint>
+  <!-- Disable collision with previous link -->
+  <disable_collisions
+    link1="${ft_config['link']['name']}"
+    link2="${ft_config['joint']['parent_link']}"
+    reason="Adjacent" />
+  <!-- Gazebo specific settings for FT sensor link -->
+  <gazebo reference="${ft_config['link']['name']}">
+    <material>Gazebo/Black</material>
+  </gazebo>
+  <!-- Enable Gazebo sensor on FT joint -->
+  <gazebo 
+    reference="${ft_config['joint']['name']}"
+    pose="${ft_config['sensor']['pose']}"
+    update_rate="${ft_config['sensor']['update_rate']}">
+    <sensor name="ft_sensor" type="force_torque">
+      <always_on>${ft_config['sensor']['always_on']}</always_on>
+      <visualize>${ft_config['sensor']['visualize']}</visualize>
+      <force_torque>
+        <frame>sensor</frame>
+        <measure_direction>${ft_config['sensor']['measure_direction']}</measure_direction>
+      </force_torque>
+    </sensor>
+  </gazebo>
+  <!-- Use gazebo_ros_pkgs ft_sensor library to publish ft_sensor_topic by referencing ft_sensor_joint -->
+  <gazebo>
+    <plugin name="${ft_config['sensor']['name']}_plugin" filename="libgazebo_ros_ft_sensor.so">
+      <topicName>${ft_config['sensor']['topic_name']}</topicName>
+      <jointName>${ft_config['joint']['name']}</jointName>
+      <noise 
+        type="${ft_config['sensor']['noise_type']}" 
+        mean="${ft_config['sensor']['noise_mean']}" 
+        stddev="${ft_config['sensor']['noise_stddev']}" />
+    </plugin>
+  </gazebo>
+
+  <!--
+    Gripper prop
+    -->
+  <link name="m_gripper_link">
+    <visual>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="$(find micropsi_packages)/meshes/m_gripper.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+      <material name="Blue">
+        <color rgba="0 0 1 1"/>
+      </material>
+    </visual>
+    <collision>
+      <origin xyz="0 0 0" rpy="0 0 0"/>
+      <geometry>
+        <mesh filename="$(find micropsi_packages)/meshes/m_gripper.stl" scale="0.001 0.001 0.001"/>
+      </geometry>
+    </collision>
+    <xacro:cylinder_inertial radius="0.035" length="0.1" mass="0.100">
+      <origin xyz="0 0 0.03" rpy="0 0 0" />
+    </xacro:cylinder_inertial>
+  </link>
+  <gazebo reference="m_gripper_link">
+    <material>Gazebo/Blue</material>
+  </gazebo>
+  <joint name="m_gripper_joint" type="fixed">
+    <parent link="${ft_config['link']['name']}" />
+    <child link="m_gripper_link" />
+    <origin 
+        xyz="0 0 ${ft_config['link']['length']/2}"
+        rpy="0 0 0" />
+    <!-- <axis xyz="0 0 1" /> -->
+    <!-- <limit lower="0" upper="0" effort="0" velocity="0" /> -->
+    <!-- <dynamics damping="0" friction="0" /> -->
+  </joint>
+  <!-- Disable collision with previous link -->
+  <disable_collisions
+    link1="${ft_config['link']['name']}"
+    link2="m_gripper_link"
+    reason="Adjacent" />
+
+  <!-- 
+    Camera link, joint, and Gazebo definition
+   -->
+   <xacro:property name="camera_config" value="${xacro.load_yaml('$(arg camera_params)')}"/>
+  <!-- Camera link -->
+  <link name="${camera_config['link']['name']}">
+    <visual>
+      <origin 
+        xyz="${camera_config['link']['origin']['xyz']}"
+        rpy="${camera_config['link']['origin']['rpy']}" />
+      <geometry>
+        <cylinder 
+          radius="${camera_config['link']['radius']}" 
+          length="${camera_config['link']['length']}" />
+      </geometry>
+    </visual>
+    <collision>
+      <origin 
+        xyz="${camera_config['link']['origin']['xyz']}"
+        rpy="${camera_config['link']['origin']['rpy']}" />
+      <geometry>
+        <cylinder 
+          radius="${camera_config['link']['radius']}" 
+          length="${camera_config['link']['length']}" />
+      </geometry>
+    </collision>
+    <inertial>
+      <mass value="${camera_config['link']['inertial']['mass']}" />
+      <origin 
+        xyz="${camera_config['link']['inertial']['origin']['xyz']}"
+        rpy="${camera_config['link']['inertial']['origin']['rpy']}" />
+      <inertia
+        ixx="${camera_config['link']['inertial']['inertia']['ixx']}"
+        ixy="${camera_config['link']['inertial']['inertia']['ixy']}"
+        ixz="${camera_config['link']['inertial']['inertia']['ixz']}"
+        iyy="${camera_config['link']['inertial']['inertia']['iyy']}"
+        iyz="${camera_config['link']['inertial']['inertia']['iyz']}"
+        izz="${camera_config['link']['inertial']['inertia']['izz']}" />
+    </inertial>
+  </link>
+  <!-- Camera joint -->
+  <joint name="${camera_config['joint']['name']}" type="revolute">
+    <parent link="${camera_config['joint']['parent_link']}" />
+    <child link="${camera_config['link']['name']}" />
+    <origin 
+        xyz="${camera_config['joint']['origin']['xyz']}"
+        rpy="${camera_config['joint']['origin']['rpy']}" />
+    <axis xyz="0 0 1" />
+    <limit lower="0" upper="0" effort="0" velocity="0" />
+    <dynamics damping="0" friction="0" />
+  </joint>
+  <!-- Disable collision with previous link -->
+  <disable_collisions 
+    link1="${camera_config['link']['name']}"
+    link2="${camera_config['joint']['parent_link']}"
+    reason="Adjacent" />
+  <!-- Gazebo specific settings for camera -->
+  <gazebo
+    reference="${camera_config['link']['name']}"
+    pose="${camera_config['camera']['pose']}" >
+    <material>Gazebo/Blue</material>
+    <sensor 
+      type="camera"
+      name="${camera_config['camera']['name']}">
+      <update_rate>${camera_config['camera']['update_rate']}</update_rate>
+      <camera
+        name="head" >
+        <horizontal_fov>${camera_config['camera']['horizontal_fov']}</horizontal_fov>
+        <image> 
+          <width>${camera_config['camera']['image']['width']}</width>
+          <height>${camera_config['camera']['image']['height']}</height>
+          <format>${camera_config['camera']['image']['format']}</format>
+        </image>
+        <clip> 
+          <near>${camera_config['camera']['clip']['near']}</near>
+          <far>${camera_config['camera']['clip']['far']}</far>
+        </clip>
+        <noise>
+          <type>${camera_config['camera']['noise_type']}</type> 
+          <mean>${camera_config['camera']['noise_mean']}</mean> 
+          <stddev>${camera_config['camera']['noise_stddev']}</stddev>
+        </noise>
+      </camera>
+      <plugin name="${camera_config['camera']['plugin']['camera_name']}_controller" filename="libgazebo_ros_triggered_camera.so">
+        <alwaysOn>${camera_config['camera']['plugin']['always_on']}</alwaysOn>
+        <cameraName>${camera_config['camera']['plugin']['camera_name']}</cameraName>
+        <imageTopicName>${camera_config['camera']['plugin']['image_topic_name']}</imageTopicName>
+        <cameraInfoTopicName>${camera_config['camera']['plugin']['camera_info_topic_name']}</cameraInfoTopicName>
+        <triggerTopicName>${camera_config['camera']['plugin']['trigger_topic_name']}</triggerTopicName>
+        <frameName>${camera_config['link']['name']}</frameName>
+        <CxPrime>${camera_config['camera']['plugin']['cx_prime']}</CxPrime>
+        <Cx>${camera_config['camera']['plugin']['cx']}</Cx>
+        <Cy>${camera_config['camera']['plugin']['cy']}</Cy>
+        <focalLength>${camera_config['camera']['plugin']['focal_length']}</focalLength>
+        <hackBaseline>${camera_config['camera']['plugin']['hack_baseline']}</hackBaseline>
+        <distortionK1>${camera_config['camera']['plugin']['distortion_k1']}</distortionK1>
+        <distortionK2>${camera_config['camera']['plugin']['distortion_k2']}</distortionK2>
+        <distortionK3>${camera_config['camera']['plugin']['distortion_k3']}</distortionK3>
+        <distortionT1>${camera_config['camera']['plugin']['distortion_t1']}</distortionT1>
+        <distortionT2>${camera_config['camera']['plugin']['distortion_t2']}</distortionT2>
+      </plugin>
+    </sensor>
+  </gazebo>
+</robot>


### PR DESCRIPTION
Create an M-picking scene for the Gazebo robot to enable analogous use. This PR references changes detailed in [this PR of `micropsi-gazebo`](https://github.com/micropsi-industries/micropsi-gazebo/pull/23). Note: this PR also builds upon a previous branch for integrating the camera. Once that PR is merged this branch must be rebased onto master (in this branch considered `micropsi-melodic-devel`).

This PR includes changes to multiple files, here I discuss one-by-one:
 - [`ur_gazebo/config/camera_base.yaml`](https://github.com/micropsi-industries/universal_robot/pull/5/commits/7a2023819237b98f1473d7da6e87ffc5b4086fcc#diff-f54efcd128b429497ed19f4d5e70b0626298b94ade08eb0df0eed4f374e4661c) the shape of the camera, its position, and its field of view have been improved to match what M-picking looks like on the real robots. The camera link is now blue.
 - changes to `ur_gazebo/config/camera_basler.yaml` and `ur_gazebo/config/camera_basler.yaml` are irrelevant, to be merged in previous branch.
 - [`ur_gazebo/config/ft_sensor.yaml`](https://github.com/micropsi-industries/universal_robot/pull/5/commits/7a2023819237b98f1473d7da6e87ffc5b4086fcc#diff-0784c9b15f725209297594c5f3d17b437df19b53d47642eab10516efdec2e773) shorten the FT sensor link to accommodate the blue M-picker.
 - [`ur_gazebo/launch/inc/ur_control.launch.xml`](https://github.com/micropsi-industries/universal_robot/pull/5/commits/7a2023819237b98f1473d7da6e87ffc5b4086fcc#diff-9333b87fb0343420a6cfb3577e6dbc1af3eb9895564f06f4ce71fbb125731dd9) change the default `empty.world` to the added (in `micropsi-gazebo`) M-picking world and launch file. Change the robot default pose to point inside the marble table.
 - [`ur_gazebo/launch/ur5e_bringup_cartesianMotion.launch`](https://github.com/micropsi-industries/universal_robot/pull/5/commits/7a2023819237b98f1473d7da6e87ffc5b4086fcc#diff-679cd4ba6e149795109e213272a1d15b41466c0a59e82da94b235d3d7da51727) the FZI controller does not like the changed _initial_ robot position. I speculate that some hard-coded defaults are present somewhere that cause the controller to try to move the robot to the original position on the ground plane. The joints position trajectory controller copes well (it also consumes less system resources on idle).
 - `ur_gazebo/urdf/ur_camera.xacro` irrelevant, to be merged in previous branch.
 - [`ur_gazebo/urdf/ur_ft_camera.xacro`](https://github.com/micropsi-industries/universal_robot/pull/5/commits/7a2023819237b98f1473d7da6e87ffc5b4086fcc#diff-63f5cfaa15668305478754bf92d5e87646b53a709f84077004c27f7fc1c0f3cb) add the M-picker gripper to the robot. This may also be added to the XAcros containing no FT sensor, but would that make sense?

Checklist:

- [x] Does the choice of the location (world file vs launch files) of added objects (table, gripper, and M) make sense? Check for code design fitment (maybe adhere to some REP guidelines?).
- [x] On a computer with an Nvidia GPU, does the lighting look good?
- [ ] Take a decision on the table, perhaps I can design one or search for one matching lab work benches.

This PR answers to ticket `MPD-2114`. Please see the matching [PR on the microspi-gazebo repo](https://github.com/micropsi-industries/micropsi-gazebo/pull/23).