### PR TITLE
Support all ur models: avoid race-condition on bringup

### DIFF
--- a/ur_gazebo/launch/inc/ur_control.launch.xml
+++ b/ur_gazebo/launch/inc/ur_control.launch.xml
@@ -58,14 +58,7 @@
     args="
       -urdf
       -param $(arg robot_description_param_name)
-      -model $(arg gazebo_model_name)
-      -J shoulder_pan_joint $(arg home_shoulder_pan)
-      -J shoulder_lift_joint $(arg home_shoulder_lift)
-      -J elbow_joint $(arg home_elbow)
-      -J wrist_1_joint $(arg home_wrist_1)
-      -J wrist_2_joint $(arg home_wrist_2)
-      -J wrist_3_joint $(arg home_wrist_3)
-      -unpause" 
+      -model $(arg gazebo_model_name)" 
       output="screen" respawn="false" />
 
   <!-- Load and start the controllers listed in the 'controllers' arg. -->


### PR DESCRIPTION
See https://github.com/micropsi-industries/micropsi-gazebo/pull/24#issuecomment-1295133629.
In the launch file `ur_gazebo/launch/inc/ur_control.launch.xml`, the joint configuration `-J` arguments are removed and the simulation is started paused.